### PR TITLE
Build preferences (only/always) if source directory has changes since last rebuild

### DIFF
--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -37,7 +37,7 @@ build-deb () {
     tmpsrc="$tmpdir/$name"
 
     info "Building Preferences UI"
-    ./ul build-preferences --skip-if-built
+    ./ul build-preferences
 
     info "Copying src to a temp dir"
     rm -rf $tmpdir/* || true

--- a/scripts/build-preferences.sh
+++ b/scripts/build-preferences.sh
@@ -5,11 +5,13 @@
 #############################################
 build-preferences () {
     set -e
-    if [[ "$1" == '--skip-if-built' ]] && [[ -d data/preferences ]]; then
-        success "Preferences are already built. Skipping."
+    NEWEST_SRC_FILE=$(ls -t preferences-src/**/* | head -n1)
+    if [[ $NEWEST_SRC_FILE -ot data/preferences ]]; then
+        echo "Detected no changes to Preferences since last build."
         return
     fi
 
+    echo "Building Preferences."
     cd preferences-src
 
     set -x

--- a/scripts/build-targz.sh
+++ b/scripts/build-targz.sh
@@ -13,7 +13,7 @@ build-targz () {
 
     set -ex
 
-    ./ul build-preferences --skip-if-built
+    ./ul build-preferences
 
     name="ulauncher"
     tmpdir="/tmp/$name"

--- a/scripts/run-ci.sh
+++ b/scripts/run-ci.sh
@@ -6,7 +6,7 @@ run-ci () {
     step1="ln -s /var/node_modules preferences-src" # take node modules from cache
     step2="cd docs && sphinx-apidoc -d 5 -o source ../ulauncher && make html && cd .."
     step3="./ul test"
-    step4="./ul build-preferences --skip-if-built"
+    step4="./ul build-preferences"
 
     exec docker run \
         --rm \


### PR DESCRIPTION
Previously it only checked if the dist directory existed with the `--skip-if-built` flag, and didn't build if it existed.

(It also builds when the dist directory doesn't exist of course)