### PR TITLE
Get tests working when Gtk4 is installed.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
 from functools import reduce
+import gi
+gi.require_version('GdkX11', '3.0')
+# pylint: disable=wrong-import-position
 from gi.repository import GdkX11
 
 import pytest


### PR DESCRIPTION
### Link to related issue (if applicable)
#52 

### Summary of the changes in this PR
I think I've resolved the issue running tests when Gtk4 is installed. Presuming the way we expect to run the tests are:

```
py.test tests
```

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [x] Use `dev` as the base branch
- [x] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [x] Write unit tests for your changes when applicable
- [x] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [x] All tests are passing

### Tested environment (distro, desktop environment and their versions)
Fedora 34 using Python 3.9.6 and Gtk 3.24.30 plus Gtk 4.2.1 installed.